### PR TITLE
Only add the interface to the bridge if it's not already there,

### DIFF
--- a/templates/openvpn-startup.erb
+++ b/templates/openvpn-startup.erb
@@ -6,5 +6,5 @@
 
 ifconfig <%= @tapdev %> &>/dev/null || openvpn --mktun --dev <%= @tapdev %>
 ifconfig <%= @tapdev %> up
-brctl addif <%= @tapbridge %> <%= @tapdev %> &>/dev/null
+brctl show <%= @tapbridge %> | grep <%= @tapdev %> &>/dev/null || brctl addif <%= @tapbridge %> <%= @tapdev %> &>/dev/null
 


### PR DESCRIPTION
otherwise it fails and openvpn won't start